### PR TITLE
dts: mt-connect: pull down gpio1 io11 at max drive strength

### DIFF
--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -34,6 +34,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_gpio_led>;
 
 		led-1 {
 			label = "ETH_GB_SEL";
@@ -596,6 +598,12 @@
 	pinctrl_pwm_led: pwmledgrp {
 		fsl,pins = <
 		MX8MM_IOMUXC_SPDIF_EXT_CLK_PWM1_OUT	0x16
+		>;
+	};
+
+	pinctrl_gpio_led: gpio-led-grp {
+		fsl,pins = <
+			MX8MM_IOMUXC_GPIO1_IO11_GPIO1_IO11		0x186
 		>;
 	};
 };


### PR DESCRIPTION
This change fixes the bug where LED4_DUAL_YELLOW is stuck high at boot. It is still a mystery what else is configuring or pulling on this PIO, but this change forces it into the correct initial state. Again, I'm very sorry for the confusion and extra churn the false result from my initial test caused