### PR TITLE
mux clock pins for the dac as gpios

### DIFF
--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -34,6 +34,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_gpio_led>;
 
 		led-1 {
 			label = "ETH_GB_SEL";
@@ -298,6 +300,8 @@
 };
 
 &gpio4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gpio4>;
 	gpio-line-names = "", "", "BRIDGE_RXD0", "BRIDGE_RXD1", "S_BRIDGE_RXD2", "S_BRIDGE_RXD3", "", "",
 		"", "", "BRIDGE_LRCLK", "BRIDGE_BCLK", "BRIDGE_TXD0", "BRIDGE_TXD1", "S_BRIDGE_TXD2", "S_BRIDGE_TXD3",
 		"", "", "", "", "", "", "", "",
@@ -305,6 +309,8 @@
 };
 
 &gpio5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gpio5>;
 	gpio-line-names = "DPM_HP_DAC_BCLK", "DPM_HP_DAC_SD", "DPM_HP_DAC_MCLK", "", "", "PWM_MEMBRANE", "", "",
 		"", "", "SPI2_SCK", "SPI2_MOSI", "SPI2_MISO", "SPI2_NSS", "", "",
 		"DPM_I2C2_SCL", "DPM_I2C2_SDA", "", "", "DPM_I2C4_SCL", "DPM_I2C4_SDA", "", "",
@@ -318,15 +324,6 @@
 	pinctrl-1 = <&pinctrl_i2c4_gpio>;
 	scl-gpios = <&gpio5 20 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpio5 21 GPIO_ACTIVE_HIGH>;
-	status = "okay";
-};
-
-&sai3 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_sai3>;
-	assigned-clocks = <&clk IMX8MM_CLK_SAI3>;
-	assigned-clock-parents = <&clk IMX8MM_AUDIO_PLL1_OUT>;
-	assigned-clock-rates = <24576000>;
 	status = "okay";
 };
 
@@ -526,14 +523,19 @@
 		>;
 	};
 
-	pinctrl_sai3: sai3grp {
+	pinctrl_gpio4: gpio4grp {
 		fsl,pins = <
-		MX8MM_IOMUXC_SAI3_TXFS_SAI3_TX_SYNC		0xd6
-		MX8MM_IOMUXC_SAI3_TXC_SAI3_TX_BCLK		0xd6
-		MX8MM_IOMUXC_SAI3_MCLK_SAI3_MCLK		0xd6
-		MX8MM_IOMUXC_SAI3_TXD_SAI3_TX_DATA0		0xd6
 		MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28		0x06 /* HP_DAC_PDN */
 		MX8MM_IOMUXC_SAI3_RXD_GPIO4_IO30		0x06 /* HP_DAC_I2C_FIL */
+		MX8MM_IOMUXC_SAI3_TXFS_GPIO4_IO31		0x26 /* DPM_HP_DAC_LRCK */
+		>;
+	};
+
+	pinctrl_gpio5: gpio5grp {
+		fsl,pins = <
+		MX8MM_IOMUXC_SAI3_TXC_GPIO5_IO0			0x26 /* DANTE_OSC_BICK */
+		MX8MM_IOMUXC_SAI3_MCLK_GPIO5_IO2		0x26 /* DANTE_OSC_MCLK */
+		MX8MM_IOMUXC_SAI3_TXD_GPIO5_IO1			0x06 /* DPM_HP_DAC_SD */
 		>;
 	};
 
@@ -631,6 +633,12 @@
 	pinctrl_pwm_led: pwmledgrp {
 		fsl,pins = <
 		MX8MM_IOMUXC_SPDIF_EXT_CLK_PWM1_OUT	0x16
+		>;
+	};
+
+	pinctrl_gpio_led: gpio-led-grp {
+		fsl,pins = <
+			MX8MM_IOMUXC_GPIO1_IO11_GPIO1_IO11		0x186
 		>;
 	};
 };

--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -276,6 +276,41 @@
 
 };
 
+&gpio1 {
+	gpio-line-names = "", "DPM_COPRO_EN", "", "", "", "", "ETH_GB_SEL", "",
+		"LED1_GREEN", "LED2_GREEN", "LED3_GREEN", "LED4_DUAL_YELLOW", "LED5_DUAL_RED", "LED4_DUAL_GREEN", "LED5_DUAL_GREEN", "",
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "";
+};
+
+&gpio2 {
+	gpio-line-names = "", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "";
+};
+
+&gpio3 {
+	gpio-line-names = "", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "";
+};
+
+&gpio4 {
+	gpio-line-names = "", "", "BRIDGE_RXD0", "BRIDGE_RXD1", "S_BRIDGE_RXD2", "S_BRIDGE_RXD3", "", "",
+		"", "", "BRIDGE_LRCLK", "BRIDGE_BCLK", "BRIDGE_TXD0", "BRIDGE_TXD1", "S_BRIDGE_TXD2", "S_BRIDGE_TXD3",
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "HP_DAC_PDN_N", "SPI2_INT", "HP_DAC_I2CFIL", "DPM_HP_DAC_LRCK";
+};
+
+&gpio5 {
+	gpio-line-names = "DPM_HP_DAC_BCLK", "DPM_HP_DAC_SD", "DPM_HP_DAC_MCLK", "", "", "PWM_MEMBRANE", "", "",
+		"", "", "SPI2_SCK", "SPI2_MOSI", "SPI2_MISO", "SPI2_NSS", "", "",
+		"DPM_I2C2_SCL", "DPM_I2C2_SDA", "", "", "DPM_I2C4_SCL", "DPM_I2C4_SDA", "", "",
+		"DPM_CONSOLE_RX", "DPM_CONSOLE_TX", "DPM_DEBUG_RX", "DPM_DEBUG_TX", "", "", "", "";
+};
+
 &i2c4 {
 	clock-frequency = <100000>;
 	pinctrl-names = "default", "gpio";


### PR DESCRIPTION
Following Brian's investigation showing the initialization of SAI3 was causing the misconfiguration of the mclk, I realized the sai3 pins were also connected to the clock generator pins among others, so those pins need to be configured as gpios with an open drain, and left floating. Since the sai3 interface is effectively useless until we have a codec, I have disabled that interface for now, and am doing the pinctrl in gpio blocks instead.