### PR TITLE
MT-126600: Comment out function call that was causing a NULL pointer exception

### DIFF
--- a/drivers/usb/chipidea/udc.c
+++ b/drivers/usb/chipidea/udc.c
@@ -1969,7 +1969,7 @@ static int ci_udc_start(struct usb_gadget *gadget,
 
 	ci->driver = driver;
 
-	if (ci_udc_enable_sg_support(gadget))
+//	if (ci_udc_enable_sg_support(gadget))
 		ci->gadget.sg_supported = 1;
 
 	/* Start otg fsm for B-device */


### PR DESCRIPTION
[MT-126600]

ChipIdea HW doesn't support Scatter-Gather well for UVC devices.

Since we are not a UVC device its ok to comment out this function call.

It is still not clear why the USB Configuration is NULL at this point 
(causing a NULL pointer exception) since this function is called with
full descriptors (device, config, interface, endpoints).


[MT-126600]: https://multitracks.atlassian.net/browse/MT-126600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ