### PR TITLE
MT-134832: Set SAI1 and SAI2 to dsp_b format

### DIFF
--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -141,7 +141,7 @@
         model = "imx-audio-card";
         pri-dai-link {
             link-name = "interproc audio";
-            format = "i2s";
+            format = "dsp_b";
 			dai-tdm-slot-num = <8>;
 			dai-tdm-slot-width = <32>;
 			fsl,mclk-equal-bclk;
@@ -156,7 +156,7 @@
         model = "imx-audio-card";		
         pri-dai-link {
             link-name = "Headphone audio";
-            format = "i2s";
+            format = "dsp_b";
 			dai-tdm-slot-num = <2>;
 			dai-tdm-slot-width = <32>;
 			fsl,mclk-equal-bclk;

--- a/sound/soc/fsl/fsl_sai.c
+++ b/sound/soc/fsl/fsl_sai.c
@@ -294,7 +294,11 @@ static int fsl_sai_set_dai_fmt_tr(struct snd_soc_dai *cpu_dai,
 		 * data word.
 		 */
 		val_cr2 |= FSL_SAI_CR2_BCP;
-		val_cr4 |= FSL_SAI_CR4_FSE | FSL_SAI_CR4_FSP;
+
+		/* NOTE: For some reason, even though we select dsp_b format, this setting is still being
+		called. The val_cr4 |= FSL_SAI_CR4_FSE | FSL_SAI_CR4_FSP is incorrect. For now on MT Connect
+		we will use this setting but corrected for our use. We MUST resolve this in future.
+		*/
 		break;
 	case SND_SOC_DAIFMT_LEFT_J:
 		/*


### PR DESCRIPTION
[MT-134832]

Setting the SAI1 and SAI3 to dsp_b format which is our required format. Works for SAI1, however does not work for SAI3 which keeps defaulting back to I2S format. Needs further investigation, but for now forcing SAI registers under I2S format to the correct settings.

Investigation can wait until after beta.

[MT-134832]: https://multitracks.atlassian.net/browse/MT-134832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ