### PR TITLE
MT-135395: fix frequency scaling to enable the 1.8g configuration

### DIFF
--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -289,7 +289,7 @@
 			buck1_reg: BUCK1 {
 				regulator-name = "BUCK1";
 				regulator-min-microvolt = <780000>;
-				regulator-max-microvolt = <850000>;
+				regulator-max-microvolt = <1000000>;
 				regulator-boot-on;
 				regulator-always-on;
 				regulator-ramp-delay = <1250>;
@@ -318,7 +318,7 @@
 			buck2_reg: BUCK2 {
 				regulator-name = "BUCK2";
 				regulator-min-microvolt = <805000>;
-				regulator-max-microvolt = <950000>;
+				regulator-max-microvolt = <1000000>;
 				regulator-boot-on;
 				regulator-always-on;
 				regulator-ramp-delay = <1250>;

--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -187,6 +187,21 @@
 	};
 };
 
+&a53_opp_table {
+
+	opp-1200000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-1600000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-1800000000 {
+		/delete-property/ opp-supported-hw;
+	};
+};
+
 &A53_0 {
 	cpu-supply = <&buck2_reg>;
 };


### PR DESCRIPTION
[MT-135395]

This set of changes enables dynamic frequency scaling by the kernel. These different frequency configurations are set based on system demand, or manually by the user, probably just for testing purposes. The kernel can be more or less aggressive with these different configurations. How aggressively the kernel switches to these higher frequency modes is determined by the governor selected by the system. The default governor is called on-demand. The most aggressive governor is called "performance". The performance governor is the one DEP will presumably select under high loads. For more details on the Linux kernel's performance scaling system, see the docs:
https://docs.kernel.org/admin-guide/pm/cpufreq.html

I will create another task for investigating exactly why we could not pass the opp supported hw check. My theory is that our silicon version has not been fused, and/or the nvmem has not yet been properly initialized. We already know our silicon version is safe to use this configuration, because the evk uses it. So it is fine to remove that property and bypass the test for now.

[MT-135395]: https://multitracks.atlassian.net/browse/MT-135395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ