### PR TITLE
Mt 146605: remove 27 uac2 channel limitation

### DIFF
--- a/Documentation/ABI/testing/configfs-usb-gadget-uac2
+++ b/Documentation/ABI/testing/configfs-usb-gadget-uac2
@@ -5,7 +5,15 @@ Description:
 		The attributes:
 
 		=====================	=======================================
-		c_chmask		capture channel mask
+		c_chmask		capture channel mask; bits 0-26 correspond
+					to the UAC2 spatial channel positions (UAC2
+					spec 4.1 Table 4-1). Masks that stay within
+					bits 0-26 are used directly as bmChannelConfig
+					in the USB descriptor. Any bit set outside
+					0-26 triggers non-predefined spatial location
+					mode (bmChannelConfig=0), which allows more
+					than 27 channels; the channel count equals
+					popcount(c_chmask) in both cases.
 		c_srate			list of capture sampling rates (comma-separated)
 		c_ssize			capture sample size (bytes)
 		c_hs_bint		capture bInterval for HS/SS (1-4: fixed, 0: auto)
@@ -20,7 +28,8 @@ Description:
 		c_volume_res		capture volume control resolution
 					(in 1/256 dB)
 		fb_max			maximum extra bandwidth in async mode
-		p_chmask		playback channel mask
+		p_chmask		playback channel mask; same semantics as
+					c_chmask above
 		p_srate			list of playback sampling rates (comma-separated)
 		p_ssize			playback sample size (bytes)
 		p_hs_bint		playback bInterval for HS/SS (1-4: fixed, 0: auto)

--- a/drivers/usb/gadget/function/f_uac2.c
+++ b/drivers/usb/gadget/function/f_uac2.c
@@ -989,10 +989,6 @@ static int afunc_validate_opts(struct g_audio *agdev, struct device *dev)
 
 	if (!opts->p_chmask && !opts->c_chmask)
 		msg = "no playback and capture channels";
-	else if (opts->p_chmask & ~UAC2_CHANNEL_MASK)
-		msg = "unsupported playback channels mask";
-	else if (opts->c_chmask & ~UAC2_CHANNEL_MASK)
-		msg = "unsupported capture channels mask";
 	else if ((opts->p_ssize < 1) || (opts->p_ssize > 4))
 		msg = "incorrect playback sample size";
 	else if ((opts->c_ssize < 1) || (opts->c_ssize > 4))
@@ -1090,14 +1086,25 @@ afunc_bind(struct usb_configuration *cfg, struct usb_function *fn)
 
 
 	/* Initialize the configurable parameters */
+	/*
+	 * UAC2 spec §4.1: bmChannelConfig bits 27-30 are reserved and must be
+	 * zero. For channel masks that exceed the 27 defined spatial positions
+	 * (bits 0-26), use bmChannelConfig=0 (non-predefined spatial locations)
+	 * with bNrChannels set from the popcount of the full mask. This is the
+	 * standard-compliant way to declare more than 27 channels.
+	 */
+	u32 c_chanconfig = (uac2_opts->c_chmask & ~UAC2_CHANNEL_MASK) ?
+		0 : uac2_opts->c_chmask;
+	u32 p_chanconfig = (uac2_opts->p_chmask & ~UAC2_CHANNEL_MASK) ?
+		0 : uac2_opts->p_chmask;
 	usb_out_it_desc.bNrChannels = num_channels(uac2_opts->c_chmask);
-	usb_out_it_desc.bmChannelConfig = cpu_to_le32(uac2_opts->c_chmask);
+	usb_out_it_desc.bmChannelConfig = cpu_to_le32(c_chanconfig);
 	io_in_it_desc.bNrChannels = num_channels(uac2_opts->p_chmask);
-	io_in_it_desc.bmChannelConfig = cpu_to_le32(uac2_opts->p_chmask);
+	io_in_it_desc.bmChannelConfig = cpu_to_le32(p_chanconfig);
 	as_out_hdr_desc.bNrChannels = num_channels(uac2_opts->c_chmask);
-	as_out_hdr_desc.bmChannelConfig = cpu_to_le32(uac2_opts->c_chmask);
+	as_out_hdr_desc.bmChannelConfig = cpu_to_le32(c_chanconfig);
 	as_in_hdr_desc.bNrChannels = num_channels(uac2_opts->p_chmask);
-	as_in_hdr_desc.bmChannelConfig = cpu_to_le32(uac2_opts->p_chmask);
+	as_in_hdr_desc.bmChannelConfig = cpu_to_le32(p_chanconfig);
 	as_out_fmt1_desc.bSubslotSize = uac2_opts->c_ssize;
 	as_out_fmt1_desc.bBitResolution = uac2_opts->c_ssize * 8;
 	as_in_fmt1_desc.bSubslotSize = uac2_opts->p_ssize;


### PR DESCRIPTION
[MT-146605]

By default, uac2 predefines 27 spatial channels, and hosts will reject anything greater than that. However, the uac2 spec specifies that if wChannelConfig=0 is set in the USB descriptors, the host is signaled that we are not using predefined channels. This special case was actually missing from the upstream driver, so I've added support for it here.

With this change, I now see 32 channels showing up in garageband on ios, and when i connect usb1 for example to linux, i can see bNrChannels=32 there, with this hacky grep from lsusb:
```
lsusb -v -d 3832:0240 2>/dev/null|grep 32
Bus 001 Device 021: ID 3832:0240 http://MultiTracks.com , LLC MT Connect 1
  idVendor           0x3832 http://MultiTracks.com , LLC
      bFunctionProtocol      32
      bInterfaceProtocol     32
        bNrChannels            32
        bmaControls(32)    0x00000000
        bNrChannels            32
        bmaControls(32)    0x00000000
      bInterfaceProtocol     32
      bInterfaceProtocol     32
        bNrChannels            32
      bInterfaceProtocol     32
      bInterfaceProtocol     32
        bNrChannels            32
```

And on mt-connect:
```
printf "0x%x\n" $(cat /sys/kernel/config/usb_gadget/mtc0/functions/uac2.usb0/c_chmask)
0xffffffff
```

That's about all I've done in terms of testing. I'm not sure what all the consequences of this will be. So far I don't think we've been using those predefined spatial channels for anything, though I have seen them show up in `pw-link ls`. I imagine it may just mean, on the output side, in iOS or Linux or wherever, we might have to manually map channels where we might otherwise have had them mapped automatically.

DevQA: @AmeNote-Michael 

[MT-146605]: https://multitracks.atlassian.net/browse/MT-146605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ