### PR TITLE
MT-151599: arm64: dts: mt-connect: fix SAI MCLK direction, add SAI2/SAI3 pinctrl, fix SAI2 dataline

### DIFF
--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -482,7 +482,7 @@
 
 /*
  * SAI2 TXFS/TXC share the Dante clock bus with SAI1 and SAI3; no data lines
- * are used. fsl,dataline must be present even with zero lanes — without it
+ * are used. fsl,dataline must be present even with zero lanes -- without it
  * fsl_sai_read_dlcfg calls devm_kzalloc(0) which returns ZERO_SIZE_PTR and
  * immediately crashes on the first cfg[0] write.
  */

--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -480,7 +480,12 @@
 	status = "okay";
 };
 
-/* SAI2 TXFS/TXC share the Dante clock bus with SAI1 and SAI3; no data lines used. */
+/*
+ * SAI2 TXFS/TXC share the Dante clock bus with SAI1 and SAI3; no data lines
+ * are used. fsl,dataline must be present even with zero lanes — without it
+ * fsl_sai_read_dlcfg calls devm_kzalloc(0) which returns ZERO_SIZE_PTR and
+ * immediately crashes on the first cfg[0] write.
+ */
 &sai2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_sai2>;
@@ -488,6 +493,7 @@
 	<&dante_osc_mclk>,
 	<&clk IMX8MM_CLK_DUMMY>, <&clk IMX8MM_CLK_DUMMY>;
 	clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
+	fsl,dataline = <1 0x00 0x00>; /* no RX or TX data lines */
 	fsl,txs-rxs;
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/freescale/mt-connect.dts
+++ b/arch/arm64/boot/dts/freescale/mt-connect.dts
@@ -439,8 +439,6 @@
 };
 
 &gpio5 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_gpio5>;
 	gpio-line-names = "DPM_HP_DAC_BCLK", "DPM_HP_DAC_SD", "DPM_HP_DAC_MCLK", "", "", "PWM_MEMBRANE", "", "",
 	"", "", "SPI2_SCK", "SPI2_MOSI", "SPI2_MISO", "SPI2_NSS", "", "",
 	"DPM_I2C2_SCL", "DPM_I2C2_SDA", "", "", "DPM_I2C4_SCL", "DPM_I2C4_SDA", "", "",
@@ -466,7 +464,6 @@
 	clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
 	fsl,dataline = <1 0x00 0x01>; /*I2S mode enabled, 0 RX lines, 1 TX lines*/
 	fsl,txs-rxs;
-	fsl,sai-mclk-direction-output;
 	status = "okay";
 };
 
@@ -480,7 +477,18 @@
 	fsl,dataline = <1 0x0F 0x0F>; /*I2S mode enabled, 4 RX lines, 4 TX lines*/
 	fsl,txs-rxs;
 	fsl,sai-multi-lane;
-	fsl,sai-mclk-direction-output;
+	status = "okay";
+};
+
+/* SAI2 TXFS/TXC share the Dante clock bus with SAI1 and SAI3; no data lines used. */
+&sai2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_sai2>;
+	clocks = <&clk IMX8MM_CLK_SAI2_IPG>, <&clk IMX8MM_CLK_DUMMY>,
+	<&dante_osc_mclk>,
+	<&clk IMX8MM_CLK_DUMMY>, <&clk IMX8MM_CLK_DUMMY>;
+	clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
+	fsl,txs-rxs;
 	status = "okay";
 };
 
@@ -688,12 +696,19 @@
 		>;
 	};
 
+	pinctrl_sai2: sai2grp {
+		fsl,pins = <
+		MX8MM_IOMUXC_SAI2_TXFS_SAI2_TX_SYNC		0x80 /* Dante LRCLK shared bus */
+		MX8MM_IOMUXC_SAI2_TXC_SAI2_TX_BCLK		0x80 /* Dante BCLK shared bus */
+		>;
+	};
 
 	pinctrl_sai3: sai3grp {
 		fsl,pins = <
 		MX8MM_IOMUXC_SAI3_TXC_SAI3_TX_BCLK		0x80 /* DANTE_OSC_SCLK */
 		MX8MM_IOMUXC_SAI3_TXD_SAI3_TX_DATA0		0xd6 /* DPM_HP_DAC_SD */
 		MX8MM_IOMUXC_SAI3_TXFS_SAI3_TX_SYNC		0x80 /* DPM_HP_DAC_LRCK */
+		MX8MM_IOMUXC_SAI3_MCLK_SAI3_MCLK		0x80 /* DANTE_OSC_MCLK input */
 		>;
 	};
 
@@ -701,12 +716,6 @@
 		fsl,pins = <
 		MX8MM_IOMUXC_SAI3_RXD_GPIO4_IO30			0x106 /* HP_DAC_I2C_FIL Pull-down */
 		MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28			0x146 /* HP_DAC_PDN Pull-up */
-		>;
-	};
-
-	pinctrl_gpio5: gpio5grp {
-		fsl,pins = <
-		MX8MM_IOMUXC_SAI3_MCLK_GPIO5_IO2			0x80 /* DANTE_OSC_MCLK */
 		>;
 	};
 


### PR DESCRIPTION
## Summary

- Remove `fsl,sai-mclk-direction-output` from SAI1 and SAI3. All MCLK signals are generated by the Dante Clocking Circuit (SI5351B) and flow *into* the A53 — none are SoC outputs. For SAI1 the MCLK pad (AB18) is NC so this was harmless; for SAI3 (AD6) the output driver was contending with the SI5351B CLK2 output.
- Move SAI3_MCLK (AD6) from `pinctrl_gpio5` to `pinctrl_sai3` using ALT0 (SAI3_MCLK function) so the 24.576 MHz Dante MCLK is properly routed into the SAI3 peripheral.
- Add `pinctrl_sai2` and enable `&sai2` (no sound card, no data lines) to claim SAI2_TXFS (AD23) and SAI2_TXC (AD22) as inputs. These pads share the Dante BCLK/LRCLK bus with SAI1 and SAI3.
- Add `fsl,dataline = <1 0x00 0x00>` to SAI2. Without this, `fsl_sai_read_dlcfg` computes `num_cfg=0`, calls `devm_kzalloc(0)` which returns `ZERO_SIZE_PTR (0x10)`, and immediately faults on the first `cfg[0]` write.
- Remove now-empty `pinctrl_gpio5` group and its reference from `&gpio5`.

## Test plan

- [x] Verified on MT Connect (iMX8MM) running kernel 6.6.36, device at 10.0.0.51
- [x] `fsl,sai-mclk-direction-output` absent from SAI1 and SAI3 DT nodes
- [x] SAI2 `fsl,dataline = <1 0x00 0x00>` present in running DT
- [x] SAI3_MCLK (pin 121) in `sai3grp` with config `0x80` (was in `gpio5grp`)
- [x] SAI2_TXFS/SAI2_TXC (pins 111/112) in `sai2grp` with config `0x80`
- [x] `gpio5grp` absent from `pinctrl-handles`
- [x] SAI2 bound to `fsl-sai` driver with no probe crash

## AI Generation Record
Tool: Claude Sonnet 4.6 (Claude Code)
Scope: Plan started with validating current "final" state of MT Connect to confirm that the hardware register settings were correct against reference manual. The above issues were realized - therefore plan extended to update the current linux-imx to implement changes. Extensive testing to validate functionality occurred. Oscilloscope used to validate signal integrity.
Security review: No credentials/keys/secrets; no GPL code; no shell injection vectors
Code review: Full local agent review.

DevQA: @dnappier-mt